### PR TITLE
Bump spring boot 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,4 +7,6 @@ on:
 
 jobs:
   build:
-    uses: valitydev/java-workflow/.github/workflows/maven-library-build.yml@v3
+    uses: valitydev/java-workflow/.github/workflows/maven-library-build.yml@v4
+    with:
+      java-version: "25"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   deploy:
-    uses: valitydev/java-workflow/.github/workflows/maven-library-deploy.yml@v3
+    uses: valitydev/java-workflow/.github/workflows/maven-library-deploy.yml@v4
+    with:
+      java-version: "25"
     secrets:
       server-username: ${{ secrets.OSSRH_USERNAME }}
       server-password: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>dev.vality</groupId>
         <artifactId>library-parent-pom</artifactId>
-        <version>3.1.0</version>
+        <version>4.0.0</version>
         <relativePath/>
     </parent>
 
     <artifactId>adapter-flow-lib</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>adapter-flow-lib</name>
@@ -44,65 +44,65 @@
         <dockerfile.registry>${env.REGISTRY}</dockerfile.registry>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <woody.version>2.0.0</woody.version>
-        <bender-proto.version>1.20-be9cdeb</bender-proto.version>
-        <damsel.version>1.670-1d0c1ec</damsel.version>
-        <apache.commons.lang3.version>3.12.0</apache.commons.lang3.version>
-        <apache.commons.codec.version>1.15</apache.commons.codec.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <lombok.version>1.18.36</lombok.version>
-        <logback.version>1.2.11</logback.version>
-        <logstash-logback-encoder.version>7.1.1</logstash-logback-encoder.version>
-        <jackson.version>2.14.0</jackson.version>
-        <junit-jupiter-engine.version>5.10.3</junit-jupiter-engine.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <validation-api.version>3.0.2</validation-api.version>
-        <spring.version>6.1.6</spring.version>
-        <spring-boot-starter.version>3.3.1</spring-boot-starter.version>
-        <cds-proto.version>1.66-01353ce</cds-proto.version>
-        <adapter-common-lib.version>3.0.0</adapter-common-lib.version>
+        <woody.version>3.0.0</woody.version>
+        <bender-proto.version>1.27-753b935</bender-proto.version>
+        <damsel.version>1.698-99c91c9</damsel.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
+        <lombok.version>1.18.46</lombok.version>
+        <logstash-logback-encoder.version>9.0</logstash-logback-encoder.version>
+        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <cds-proto.version>1.71-b3db02c</cds-proto.version>
+        <msgpack-proto.version>1.17-7481bb4</msgpack-proto.version>
+        <geck.version>1.0.2</geck.version>
+        <adapter-common-lib.version>4.0.0</adapter-common-lib.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- springframework -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
-            <version>${spring-boot-starter.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <!-- Third party libs -->
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>${validation-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${apache.commons.lang3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${apache.commons.codec.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -113,13 +113,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -129,14 +127,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <!--Vality libs-->
@@ -153,9 +145,27 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>dev.vality.woody</groupId>
+            <artifactId>woody-api</artifactId>
+            <version>${woody.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.vality.woody</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>${woody.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>dev.vality</groupId>
             <artifactId>bender-proto</artifactId>
             <version>${bender-proto.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.vality</groupId>
+            <artifactId>msgpack-proto</artifactId>
+            <version>${msgpack-proto.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -175,31 +185,27 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring-boot-starter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>${spring-boot-starter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot-starter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter-engine.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>dev.vality.geck</groupId>
             <artifactId>serializer</artifactId>
-            <version>0.0.1</version>
+            <version>${geck.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -221,6 +227,13 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <parameters>true</parameters>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/dev/vality/adapter/flow/lib/logback/mask/MaskedEvent.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/logback/mask/MaskedEvent.java
@@ -6,7 +6,9 @@ import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.LoggerContextVO;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
 
+import java.util.List;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -71,6 +73,11 @@ public class MaskedEvent implements ILoggingEvent {
     }
 
     @Override
+    public List<Marker> getMarkerList() {
+        return event.getMarkerList();
+    }
+
+    @Override
     public Map<String, String> getMDCPropertyMap() {
         return event.getMDCPropertyMap();
     }
@@ -83,6 +90,21 @@ public class MaskedEvent implements ILoggingEvent {
     @Override
     public long getTimeStamp() {
         return event.getTimeStamp();
+    }
+
+    @Override
+    public int getNanoseconds() {
+        return event.getNanoseconds();
+    }
+
+    @Override
+    public long getSequenceNumber() {
+        return event.getSequenceNumber();
+    }
+
+    @Override
+    public List<KeyValuePair> getKeyValuePairs() {
+        return event.getKeyValuePairs();
     }
 
     @Override

--- a/src/main/java/dev/vality/adapter/flow/lib/logback/mask/PatternMaskingMessageJsonProvider.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/logback/mask/PatternMaskingMessageJsonProvider.java
@@ -1,13 +1,12 @@
 package dev.vality.adapter.flow.lib.logback.mask;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.fasterxml.jackson.core.JsonGenerator;
 import net.logstash.logback.composite.AbstractFieldJsonProvider;
 import net.logstash.logback.composite.FieldNamesAware;
 import net.logstash.logback.composite.JsonWritingUtils;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
+import tools.jackson.core.JsonGenerator;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -29,7 +28,7 @@ public class PatternMaskingMessageJsonProvider extends AbstractFieldJsonProvider
     }
 
     @Override
-    public void writeTo(JsonGenerator generator, ILoggingEvent event) throws IOException {
+    public void writeTo(JsonGenerator generator, ILoggingEvent event) {
         JsonWritingUtils.writeStringField(generator, getFieldName(),
                 MaskingMessageWithPattern.maskMessage(event.getFormattedMessage(), multilinePattern)
         );

--- a/src/main/java/dev/vality/adapter/flow/lib/serde/ParametersDeserializer.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/serde/ParametersDeserializer.java
@@ -1,12 +1,12 @@
 package dev.vality.adapter.flow.lib.serde;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.vality.adapter.flow.lib.exception.DeserializationException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -24,7 +24,7 @@ public class ParametersDeserializer implements Deserializer<Map<String, String>>
             try {
                 return mapper.readValue(data, new TypeReference<HashMap<String, String>>() {
                 });
-            } catch (IOException ex) {
+            } catch (JacksonException ex) {
                 throw new IllegalArgumentException(ex);
             }
         }

--- a/src/main/java/dev/vality/adapter/flow/lib/serde/ParametersSerializer.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/serde/ParametersSerializer.java
@@ -1,6 +1,6 @@
 package dev.vality.adapter.flow.lib.serde;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.Map;
 

--- a/src/main/java/dev/vality/adapter/flow/lib/serde/StateSerializer.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/serde/StateSerializer.java
@@ -1,12 +1,12 @@
 package dev.vality.adapter.flow.lib.serde;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.SerializationException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
 import java.util.Base64;
 
 @Getter
@@ -20,7 +20,7 @@ public abstract class StateSerializer<T> implements Serializer<T> {
     public byte[] writeByte(Object obj) {
         try {
             return mapper.writeValueAsBytes(obj);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new SerializationException(e);
         }
     }
@@ -29,7 +29,7 @@ public abstract class StateSerializer<T> implements Serializer<T> {
     public String writeString(Object obj) {
         try {
             return Base64.getEncoder().encodeToString(getMapper().writeValueAsBytes(obj));
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new SerializationException(e);
         }
     }

--- a/src/main/java/dev/vality/adapter/flow/lib/serde/TemporaryContextDeserializer.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/serde/TemporaryContextDeserializer.java
@@ -1,10 +1,9 @@
 package dev.vality.adapter.flow.lib.serde;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.vality.adapter.flow.lib.exception.DeserializationException;
 import dev.vality.adapter.flow.lib.model.TemporaryContext;
-
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 public class TemporaryContextDeserializer implements Deserializer<TemporaryContext> {
 
@@ -16,7 +15,7 @@ public class TemporaryContextDeserializer implements Deserializer<TemporaryConte
         } else {
             try {
                 return this.getMapper().readValue(data, TemporaryContext.class);
-            } catch (IOException var3) {
+            } catch (JacksonException var3) {
                 throw new IllegalArgumentException(var3);
             }
         }

--- a/src/main/java/dev/vality/adapter/flow/lib/serde/TemporaryContextSerializer.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/serde/TemporaryContextSerializer.java
@@ -1,7 +1,7 @@
 package dev.vality.adapter.flow.lib.serde;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.vality.adapter.flow.lib.model.TemporaryContext;
+import tools.jackson.databind.ObjectMapper;
 
 public class TemporaryContextSerializer extends StateSerializer<TemporaryContext> {
     public TemporaryContextSerializer(ObjectMapper mapper) {

--- a/src/main/java/dev/vality/adapter/flow/lib/service/factory/IntentResultForwardThreeDsParamsFactory.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/service/factory/IntentResultForwardThreeDsParamsFactory.java
@@ -1,6 +1,6 @@
 package dev.vality.adapter.flow.lib.service.factory;
 
-import dev.vality.adapter.common.mapper.ErrorMapping;
+import dev.vality.adapter.common.v2.mapper.ErrorMapping;
 import dev.vality.adapter.flow.lib.constant.HttpMethod;
 import dev.vality.adapter.flow.lib.model.EntryStateModel;
 import dev.vality.adapter.flow.lib.model.ExitStateModel;
@@ -14,7 +14,12 @@ import dev.vality.adapter.flow.lib.utils.ThreeDsDataInitializer;
 import dev.vality.adapter.flow.lib.utils.TimeoutUtils;
 import dev.vality.adapter.flow.lib.utils.TimerProperties;
 import dev.vality.damsel.base.Timer;
-import dev.vality.damsel.proxy_provider.*;
+import dev.vality.damsel.proxy_provider.FinishIntent;
+import dev.vality.damsel.proxy_provider.FinishStatus;
+import dev.vality.damsel.proxy_provider.Intent;
+import dev.vality.damsel.proxy_provider.SleepIntent;
+import dev.vality.damsel.proxy_provider.Success;
+import dev.vality.damsel.proxy_provider.SuspendIntent;
 import dev.vality.damsel.timeout_behaviour.TimeoutBehaviour;
 import dev.vality.damsel.user_interaction.UserInteraction;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +29,9 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 import static dev.vality.adapter.common.damsel.OptionsExtractors.extractRedirectTimeout;
-import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.*;
+import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.createFinishIntentSuccessWithToken;
+import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.createGetUserInteraction;
+import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.createPostUserInteraction;
 
 @RequiredArgsConstructor
 public class IntentResultForwardThreeDsParamsFactory implements IntentResultFactory {

--- a/src/main/java/dev/vality/adapter/flow/lib/service/factory/IntentResultQrPaymentFactory.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/service/factory/IntentResultQrPaymentFactory.java
@@ -1,6 +1,6 @@
 package dev.vality.adapter.flow.lib.service.factory;
 
-import dev.vality.adapter.common.mapper.ErrorMapping;
+import dev.vality.adapter.common.v2.mapper.ErrorMapping;
 import dev.vality.adapter.flow.lib.model.EntryStateModel;
 import dev.vality.adapter.flow.lib.model.ExitStateModel;
 import dev.vality.adapter.flow.lib.model.PollingInfo;
@@ -12,7 +12,12 @@ import dev.vality.adapter.flow.lib.service.TagManagementService;
 import dev.vality.adapter.flow.lib.utils.TimeoutUtils;
 import dev.vality.adapter.flow.lib.utils.TimerProperties;
 import dev.vality.damsel.base.Timer;
-import dev.vality.damsel.proxy_provider.*;
+import dev.vality.damsel.proxy_provider.FinishIntent;
+import dev.vality.damsel.proxy_provider.FinishStatus;
+import dev.vality.damsel.proxy_provider.Intent;
+import dev.vality.damsel.proxy_provider.SleepIntent;
+import dev.vality.damsel.proxy_provider.Success;
+import dev.vality.damsel.proxy_provider.SuspendIntent;
 import dev.vality.damsel.timeout_behaviour.TimeoutBehaviour;
 import dev.vality.damsel.user_interaction.QrCode;
 import dev.vality.damsel.user_interaction.QrCodeDisplayRequest;

--- a/src/main/java/dev/vality/adapter/flow/lib/service/factory/SimpleIntentResultFactory.java
+++ b/src/main/java/dev/vality/adapter/flow/lib/service/factory/SimpleIntentResultFactory.java
@@ -1,6 +1,6 @@
 package dev.vality.adapter.flow.lib.service.factory;
 
-import dev.vality.adapter.common.mapper.ErrorMapping;
+import dev.vality.adapter.common.v2.mapper.ErrorMapping;
 import dev.vality.adapter.flow.lib.constant.HttpMethod;
 import dev.vality.adapter.flow.lib.constant.RedirectFields;
 import dev.vality.adapter.flow.lib.model.EntryStateModel;
@@ -16,7 +16,12 @@ import dev.vality.adapter.flow.lib.utils.ThreeDsDataInitializer;
 import dev.vality.adapter.flow.lib.utils.TimeoutUtils;
 import dev.vality.adapter.flow.lib.utils.TimerProperties;
 import dev.vality.damsel.base.Timer;
-import dev.vality.damsel.proxy_provider.*;
+import dev.vality.damsel.proxy_provider.FinishIntent;
+import dev.vality.damsel.proxy_provider.FinishStatus;
+import dev.vality.damsel.proxy_provider.Intent;
+import dev.vality.damsel.proxy_provider.SleepIntent;
+import dev.vality.damsel.proxy_provider.Success;
+import dev.vality.damsel.proxy_provider.SuspendIntent;
 import dev.vality.damsel.timeout_behaviour.TimeoutBehaviour;
 import dev.vality.damsel.user_interaction.UserInteraction;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +31,9 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 
 import static dev.vality.adapter.common.damsel.OptionsExtractors.extractRedirectTimeout;
-import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.*;
+import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.createFinishIntentSuccessWithToken;
+import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.createGetUserInteraction;
+import static dev.vality.adapter.common.damsel.ProxyProviderPackageCreators.createPostUserInteraction;
 
 @RequiredArgsConstructor
 public class SimpleIntentResultFactory implements IntentResultFactory {

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/AbstractGenerateTokenTest.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/AbstractGenerateTokenTest.java
@@ -5,7 +5,11 @@ import dev.vality.adapter.common.hellgate.HellgateClient;
 import dev.vality.adapter.flow.lib.client.RemoteClient;
 import dev.vality.adapter.flow.lib.constant.Step;
 import dev.vality.adapter.flow.lib.controller.ThreeDsCallbackController;
-import dev.vality.adapter.flow.lib.flow.config.*;
+import dev.vality.adapter.flow.lib.flow.config.AppConfig;
+import dev.vality.adapter.flow.lib.flow.config.HandlerConfig;
+import dev.vality.adapter.flow.lib.flow.config.ProcessorConfig;
+import dev.vality.adapter.flow.lib.flow.config.SerdeConfig;
+import dev.vality.adapter.flow.lib.flow.config.TomcatEmbeddedConfiguration;
 import dev.vality.adapter.flow.lib.flow.full.FullThreeDsAllVersionsStepResolverImpl;
 import dev.vality.adapter.flow.lib.flow.full.GenerateTokenFullThreeDsAllVersionsStepResolverImpl;
 import dev.vality.adapter.flow.lib.serde.TemporaryContextDeserializer;
@@ -19,13 +23,13 @@ import dev.vality.damsel.proxy_provider.PaymentProxyResult;
 import dev.vality.damsel.proxy_provider.ProviderProxySrv;
 import org.apache.thrift.TException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static dev.vality.adapter.common.damsel.DomainPackageCreators.createTargetProcessed;
-import static dev.vality.adapter.flow.lib.flow.full.three.ds.ForwardRecurrentPaymentNon3dsTest.RECURRENT_TOKEN;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @PropertySource("classpath:application.yaml")
 @ContextConfiguration(classes = {HandlerConfig.class, AppConfig.class, ProcessorConfig.class, SerdeConfig.class,
@@ -34,15 +38,15 @@ import static org.junit.jupiter.api.Assertions.*;
         GenerateTokenFullThreeDsAllVersionsStepResolverImpl.class})
 public class AbstractGenerateTokenTest {
 
-    @MockBean
+    @MockitoBean
     protected CdsStorageClient cdsStorageClient;
-    @MockBean
+    @MockitoBean
     protected AdapterConfigurationValidator paymentContextValidator;
-    @MockBean
+    @MockitoBean
     protected BenderSrv.Iface benderClient;
-    @MockBean
+    @MockitoBean
     protected RemoteClient client;
-    @MockBean
+    @MockitoBean
     protected HellgateClient hellgateClient;
     @Autowired
     public TemporaryContextDeserializer temporaryContextDeserializer;

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/AbstractPaymentTest.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/AbstractPaymentTest.java
@@ -6,7 +6,11 @@ import dev.vality.adapter.common.hellgate.HellgateClient;
 import dev.vality.adapter.flow.lib.client.RemoteClient;
 import dev.vality.adapter.flow.lib.constant.Step;
 import dev.vality.adapter.flow.lib.controller.ThreeDsCallbackController;
-import dev.vality.adapter.flow.lib.flow.config.*;
+import dev.vality.adapter.flow.lib.flow.config.AppConfig;
+import dev.vality.adapter.flow.lib.flow.config.HandlerConfig;
+import dev.vality.adapter.flow.lib.flow.config.ProcessorConfig;
+import dev.vality.adapter.flow.lib.flow.config.SerdeConfig;
+import dev.vality.adapter.flow.lib.flow.config.TomcatEmbeddedConfiguration;
 import dev.vality.adapter.flow.lib.flow.full.FullThreeDsAllVersionsStepResolverImpl;
 import dev.vality.adapter.flow.lib.flow.full.GenerateTokenFullThreeDsAllVersionsStepResolverImpl;
 import dev.vality.adapter.flow.lib.serde.TemporaryContextDeserializer;
@@ -17,15 +21,23 @@ import dev.vality.bender.BenderSrv;
 import dev.vality.damsel.domain.InvoicePaymentCaptured;
 import dev.vality.damsel.domain.InvoicePaymentRefunded;
 import dev.vality.damsel.domain.TargetInvoicePaymentStatus;
-import dev.vality.damsel.proxy_provider.*;
+import dev.vality.damsel.proxy_provider.Cash;
+import dev.vality.damsel.proxy_provider.InvoicePaymentRefund;
+import dev.vality.damsel.proxy_provider.PaymentCallbackResult;
+import dev.vality.damsel.proxy_provider.PaymentContext;
+import dev.vality.damsel.proxy_provider.PaymentProxyResult;
+import dev.vality.damsel.proxy_provider.ProviderProxySrv;
+import dev.vality.damsel.proxy_provider.Success;
 import org.apache.thrift.TException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static dev.vality.adapter.common.damsel.DomainPackageCreators.createTargetProcessed;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @PropertySource("classpath:application.yaml")
 @ContextConfiguration(classes = {HandlerConfig.class, AppConfig.class, ProcessorConfig.class, SerdeConfig.class,
@@ -34,15 +46,15 @@ import static org.junit.jupiter.api.Assertions.*;
         GenerateTokenFullThreeDsAllVersionsStepResolverImpl.class})
 public class AbstractPaymentTest {
 
-    @MockBean
+    @MockitoBean
     protected CdsStorageClient cdsStorageClient;
-    @MockBean
+    @MockitoBean
     protected BenderSrv.Iface benderClient;
-    @MockBean
+    @MockitoBean
     protected RemoteClient client;
-    @MockBean
+    @MockitoBean
     protected HellgateClient hellgateClient;
-    @MockBean
+    @MockitoBean
     protected AdapterConfigurationValidator paymentContextValidator;
 
     @Autowired

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/config/AppConfig.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/config/AppConfig.java
@@ -5,12 +5,11 @@ import dev.vality.adapter.common.v2.mapper.ErrorMapping;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import tools.jackson.databind.DeserializationFeature;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 
@@ -38,10 +37,8 @@ public class AppConfig {
     }
 
     @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper()
-                .rebuild()
+    public JsonMapper objectMapper() {
+        return JsonMapper.builder()
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
     }

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/config/AppConfig.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/config/AppConfig.java
@@ -1,10 +1,7 @@
 package dev.vality.adapter.flow.lib.flow.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import dev.vality.adapter.common.component.SimpleErrorMapping;
-import dev.vality.adapter.common.mapper.ErrorMapping;
+import dev.vality.adapter.common.v2.mapper.ErrorMapping;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +9,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -32,15 +31,18 @@ public class AppConfig {
     @Bean
     public ErrorMapping errorMapping(@Value("${error-mapping.file}") Resource errorMappingFilePath,
                                      @Value("${error-mapping.patternReason:\"'%s' - '%s'\"}")
-                                             String errorMappingPattern) throws IOException {
-        return new SimpleErrorMapping(errorMappingFilePath, errorMappingPattern).createErrorMapping();
+                                     String errorMappingPattern)
+            throws IOException {
+        return new SimpleErrorMapping(errorMappingFilePath, errorMappingPattern)
+                .createErrorMapping();
     }
 
     @Bean
     @Primary
     public ObjectMapper objectMapper() {
         return new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+                .rebuild()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
     }
 }

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/config/HandlerConfig.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/config/HandlerConfig.java
@@ -1,9 +1,8 @@
 package dev.vality.adapter.flow.lib.flow.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.vality.adapter.common.cds.CdsStorageClient;
 import dev.vality.adapter.common.hellgate.HellgateClient;
-import dev.vality.adapter.common.mapper.ErrorMapping;
+import dev.vality.adapter.common.v2.mapper.ErrorMapping;
 import dev.vality.adapter.flow.lib.converter.ExitStateModelToTemporaryContextConverter;
 import dev.vality.adapter.flow.lib.converter.base.EntryModelToBaseRequestModelConverter;
 import dev.vality.adapter.flow.lib.converter.entry.CtxToEntryModelConverter;
@@ -17,7 +16,17 @@ import dev.vality.adapter.flow.lib.serde.ParametersDeserializer;
 import dev.vality.adapter.flow.lib.serde.ParametersSerializer;
 import dev.vality.adapter.flow.lib.serde.TemporaryContextDeserializer;
 import dev.vality.adapter.flow.lib.serde.TemporaryContextSerializer;
-import dev.vality.adapter.flow.lib.service.*;
+import dev.vality.adapter.flow.lib.service.BenderGenerator;
+import dev.vality.adapter.flow.lib.service.CallbackUrlExtractor;
+import dev.vality.adapter.flow.lib.service.CardDataServiceWithHolderNamesImpl;
+import dev.vality.adapter.flow.lib.service.CardHolderNamesService;
+import dev.vality.adapter.flow.lib.service.ExponentialBackOffPollingService;
+import dev.vality.adapter.flow.lib.service.IdGenerator;
+import dev.vality.adapter.flow.lib.service.PollingInfoService;
+import dev.vality.adapter.flow.lib.service.TagManagementService;
+import dev.vality.adapter.flow.lib.service.TagManagementServiceImpl;
+import dev.vality.adapter.flow.lib.service.TemporaryContextService;
+import dev.vality.adapter.flow.lib.service.ThreeDsAdapterService;
 import dev.vality.adapter.flow.lib.service.factory.IntentResultFactory;
 import dev.vality.adapter.flow.lib.service.factory.SimpleIntentResultFactory;
 import dev.vality.adapter.flow.lib.utils.AdapterProperties;
@@ -31,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/config/SerdeConfig.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/config/SerdeConfig.java
@@ -1,11 +1,11 @@
 package dev.vality.adapter.flow.lib.flow.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.vality.adapter.flow.lib.serde.ParametersDeserializer;
 import dev.vality.adapter.flow.lib.serde.TemporaryContextDeserializer;
 import dev.vality.adapter.flow.lib.serde.TemporaryContextSerializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 public class SerdeConfig {

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/config/TomcatEmbeddedConfiguration.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/config/TomcatEmbeddedConfiguration.java
@@ -8,9 +8,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.catalina.connector.Connector;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.servlet.ServletWebServerFactory;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -33,7 +33,7 @@ public class TomcatEmbeddedConfiguration {
         TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory();
         Connector connector = new Connector();
         connector.setPort(restPort);
-        tomcat.addAdditionalTomcatConnectors(connector);
+        tomcat.addAdditionalConnectors(connector);
         return tomcat;
     }
 

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/full/three/ds/PaymentSuccess3ds1Test.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/full/three/ds/PaymentSuccess3ds1Test.java
@@ -1,6 +1,5 @@
 package dev.vality.adapter.flow.lib.flow.full.three.ds;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.vality.adapter.flow.lib.constant.Status;
 import dev.vality.adapter.flow.lib.constant.Step;
 import dev.vality.adapter.flow.lib.flow.AbstractPaymentTest;
@@ -21,6 +20,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import tools.jackson.core.JacksonException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -75,7 +75,7 @@ public class PaymentSuccess3ds1Test extends AbstractPaymentTest {
         test3ds1(options);
     }
 
-    private void test3ds1(Map<String, String> options) throws TException, JsonProcessingException {
+    private void test3ds1(Map<String, String> options) throws TException, JacksonException {
         PaymentContext paymentContext = MockUtil.buildPaymentContext("invoice_id", options);
 
         PaymentProxyResult paymentProxyResult = serverHandlerLogDecorator.processPayment(paymentContext);
@@ -94,7 +94,7 @@ public class PaymentSuccess3ds1Test extends AbstractPaymentTest {
 
         //capture
         PaymentProxyResult paymentProxyResultDeposit =
-                checkSuccessCapture(paymentContext, paymentProxyResult, new byte[] {});
+                checkSuccessCapture(paymentContext, paymentProxyResult, new byte[]{});
 
         //refund
         checkSuccessRefund(1100L, paymentContext, paymentProxyResultDeposit);

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/full/three/ds/PaymentSuccess3ds2FullTest.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/full/three/ds/PaymentSuccess3ds2FullTest.java
@@ -1,6 +1,5 @@
 package dev.vality.adapter.flow.lib.flow.full.three.ds;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.vality.adapter.flow.lib.constant.Status;
 import dev.vality.adapter.flow.lib.constant.Step;
 import dev.vality.adapter.flow.lib.flow.AbstractPaymentTest;
@@ -21,6 +20,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import tools.jackson.core.JacksonException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -78,7 +78,7 @@ public class PaymentSuccess3ds2FullTest extends AbstractPaymentTest {
         test3ds2Full(options);
     }
 
-    private void test3ds2Full(Map<String, String> options) throws TException, JsonProcessingException {
+    private void test3ds2Full(Map<String, String> options) throws TException, JacksonException {
         // auth
         PaymentContext paymentContext = MockUtil.buildPaymentContext("invoice_id", options);
 
@@ -106,7 +106,7 @@ public class PaymentSuccess3ds2FullTest extends AbstractPaymentTest {
 
         //capture
         PaymentProxyResult paymentProxyResultDeposit =
-                checkSuccessCapture(paymentContext, paymentProxyResult, new byte[] {});
+                checkSuccessCapture(paymentContext, paymentProxyResult, new byte[]{});
 
         //refund
         checkSuccessRefund(1100L, paymentContext, paymentProxyResultDeposit);

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/full/three/ds/PaymentSuccess3ds2SimpleTest.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/full/three/ds/PaymentSuccess3ds2SimpleTest.java
@@ -1,6 +1,5 @@
 package dev.vality.adapter.flow.lib.flow.full.three.ds;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.vality.adapter.flow.lib.constant.Status;
 import dev.vality.adapter.flow.lib.constant.Step;
 import dev.vality.adapter.flow.lib.flow.AbstractPaymentTest;
@@ -21,6 +20,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import tools.jackson.core.JacksonException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -72,7 +72,7 @@ public class PaymentSuccess3ds2SimpleTest extends AbstractPaymentTest {
         test3ds2Full(options);
     }
 
-    private void test3ds2Full(Map<String, String> options) throws TException, JsonProcessingException {
+    private void test3ds2Full(Map<String, String> options) throws TException, JacksonException {
         // auth
         PaymentContext paymentContext = MockUtil.buildPaymentContext("invoice_id", options);
 
@@ -96,7 +96,7 @@ public class PaymentSuccess3ds2SimpleTest extends AbstractPaymentTest {
 
         //capture
         PaymentProxyResult paymentProxyResultDeposit =
-                checkSuccessCapture(paymentContext, paymentProxyResult, new byte[] {});
+                checkSuccessCapture(paymentContext, paymentProxyResult, new byte[]{});
 
         //refund
         checkSuccessRefund(1100L, paymentContext, paymentProxyResultDeposit);

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/qr/PaymentSuccessQrTest.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/qr/PaymentSuccessQrTest.java
@@ -1,6 +1,5 @@
 package dev.vality.adapter.flow.lib.flow.qr;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.vality.adapter.flow.lib.constant.OptionFields;
 import dev.vality.adapter.flow.lib.constant.Stage;
 import dev.vality.adapter.flow.lib.constant.Status;
@@ -22,6 +21,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import tools.jackson.core.JacksonException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -72,7 +72,7 @@ public class PaymentSuccessQrTest extends AbstractPaymentTest {
         testQr(options);
     }
 
-    private void testQr(Map<String, String> options) throws TException, JsonProcessingException {
+    private void testQr(Map<String, String> options) throws TException, JacksonException {
         PaymentContext paymentContext = MockUtil.buildPaymentContextPaymentTerminal("invoice_id", options);
 
         PaymentProxyResult paymentProxyResult = serverHandlerLogDecorator.processPayment(paymentContext);
@@ -85,10 +85,10 @@ public class PaymentSuccessQrTest extends AbstractPaymentTest {
 
         //capture
         if (Stage.ONE.equals(options.get(OptionFields.STAGE.name()))) {
-            paymentProxyResult = checkSuccessCapture(paymentContext, paymentProxyResult, new byte[] {});
+            paymentProxyResult = checkSuccessCapture(paymentContext, paymentProxyResult, new byte[]{});
             processWithDoNothingSuccessResult(paymentContext, paymentProxyResult);
         } else {
-            paymentProxyResult = processCaptureWithCheckStatusResult(paymentContext, paymentProxyResult, new byte[] {});
+            paymentProxyResult = processCaptureWithCheckStatusResult(paymentContext, paymentProxyResult, new byte[]{});
             processWithCheckStatusResult(paymentContext, paymentProxyResult);
         }
 

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/qr/config/QrRedirectWithPollingDsFlowConfig.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/qr/config/QrRedirectWithPollingDsFlowConfig.java
@@ -1,6 +1,6 @@
 package dev.vality.adapter.flow.lib.flow.qr.config;
 
-import dev.vality.adapter.common.mapper.ErrorMapping;
+import dev.vality.adapter.common.v2.mapper.ErrorMapping;
 import dev.vality.adapter.flow.lib.client.RemoteClient;
 import dev.vality.adapter.flow.lib.converter.base.EntryModelToBaseRequestModelConverter;
 import dev.vality.adapter.flow.lib.converter.entry.CtxToEntryModelConverter;
@@ -13,11 +13,21 @@ import dev.vality.adapter.flow.lib.flow.simple.UnsupportedGenerateTokenStepResol
 import dev.vality.adapter.flow.lib.handler.CommonHandler;
 import dev.vality.adapter.flow.lib.handler.ServerFlowHandler;
 import dev.vality.adapter.flow.lib.handler.ServerFlowHandlerImpl;
-import dev.vality.adapter.flow.lib.handler.payment.*;
+import dev.vality.adapter.flow.lib.handler.payment.AuthHandler;
+import dev.vality.adapter.flow.lib.handler.payment.CancelHandler;
+import dev.vality.adapter.flow.lib.handler.payment.CaptureHandler;
+import dev.vality.adapter.flow.lib.handler.payment.DoNothingHandler;
+import dev.vality.adapter.flow.lib.handler.payment.PaymentHandler;
+import dev.vality.adapter.flow.lib.handler.payment.RefundHandler;
+import dev.vality.adapter.flow.lib.handler.payment.StatusHandler;
 import dev.vality.adapter.flow.lib.model.BaseResponseModel;
 import dev.vality.adapter.flow.lib.model.EntryStateModel;
 import dev.vality.adapter.flow.lib.model.ExitStateModel;
-import dev.vality.adapter.flow.lib.processor.*;
+import dev.vality.adapter.flow.lib.processor.ErrorProcessor;
+import dev.vality.adapter.flow.lib.processor.Processor;
+import dev.vality.adapter.flow.lib.processor.QrDisplayProcessor;
+import dev.vality.adapter.flow.lib.processor.RetryProcessor;
+import dev.vality.adapter.flow.lib.processor.SuccessFinishProcessor;
 import dev.vality.adapter.flow.lib.serde.ParametersSerializer;
 import dev.vality.adapter.flow.lib.service.ExponentialBackOffPollingService;
 import dev.vality.adapter.flow.lib.service.PollingInfoService;

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/simple/redirect/PaymentSuccess3dsTest.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/simple/redirect/PaymentSuccess3dsTest.java
@@ -1,6 +1,5 @@
 package dev.vality.adapter.flow.lib.flow.simple.redirect;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.vality.adapter.flow.lib.constant.OptionFields;
 import dev.vality.adapter.flow.lib.constant.Stage;
 import dev.vality.adapter.flow.lib.constant.Status;
@@ -22,6 +21,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import tools.jackson.core.JacksonException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -78,7 +78,7 @@ public class PaymentSuccess3dsTest extends AbstractPaymentTest {
         test3ds1(options);
     }
 
-    private void test3ds1(Map<String, String> options) throws TException, JsonProcessingException {
+    private void test3ds1(Map<String, String> options) throws TException, JacksonException {
         PaymentContext paymentContext = MockUtil.buildPaymentContext("invoice_id", options);
 
         PaymentProxyResult paymentProxyResult = serverHandlerLogDecorator.processPayment(paymentContext);
@@ -91,10 +91,10 @@ public class PaymentSuccess3dsTest extends AbstractPaymentTest {
 
         //capture
         if (Stage.ONE.equals(options.get(OptionFields.STAGE.name()))) {
-            paymentProxyResult = checkSuccessCapture(paymentContext, paymentProxyResult, new byte[] {});
+            paymentProxyResult = checkSuccessCapture(paymentContext, paymentProxyResult, new byte[]{});
             processWithDoNothingSuccessResult(paymentContext, paymentProxyResult);
         } else {
-            paymentProxyResult = processCaptureWithCheckStatusResult(paymentContext, paymentProxyResult, new byte[] {});
+            paymentProxyResult = processCaptureWithCheckStatusResult(paymentContext, paymentProxyResult, new byte[]{});
             processWithCheckStatusResult(paymentContext, paymentProxyResult);
         }
 

--- a/src/test/java/dev/vality/adapter/flow/lib/flow/utils/BeanUtils.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/flow/utils/BeanUtils.java
@@ -1,12 +1,12 @@
 package dev.vality.adapter.flow.lib.flow.utils;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import dev.vality.adapter.common.utils.CommonConverter;
 import dev.vality.adapter.flow.lib.constant.Status;
 import dev.vality.adapter.flow.lib.constant.ThreeDsType;
 import dev.vality.adapter.flow.lib.model.BaseResponseModel;
 import dev.vality.adapter.flow.lib.model.QrDisplayData;
 import dev.vality.adapter.flow.lib.model.ThreeDsData;
+import tools.jackson.core.JacksonException;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -71,14 +71,14 @@ public class BeanUtils {
                 .build();
     }
 
-    public static ByteBuffer createParesBuffer(String pares, String md) throws JsonProcessingException {
+    public static ByteBuffer createParesBuffer(String pares, String md) throws JacksonException {
         Map<String, String> map = new HashMap<>();
         map.put(PA_RES, pares);
         map.put(MD, md);
         return CommonConverter.mapToByteBuffer(map);
     }
 
-    public static ByteBuffer createCresBuffer(String cres, String threeDSSessionData) throws JsonProcessingException {
+    public static ByteBuffer createCresBuffer(String cres, String threeDSSessionData) throws JacksonException {
         Map<String, String> map = new HashMap<>();
         map.put(C_RES, cres);
         map.put(THREE_DS_SESSION_DATA, threeDSSessionData);
@@ -86,7 +86,7 @@ public class BeanUtils {
     }
 
     public static ByteBuffer createSessionBuffer(String methodData, String threeDSSessionData)
-            throws JsonProcessingException {
+            throws JacksonException {
         Map<String, String> map = new HashMap<>();
         map.put(THREE_DS_METHOD_DATA, methodData);
         map.put(THREE_DS_METHOD_STATE, threeDSSessionData);

--- a/src/test/java/dev/vality/adapter/flow/lib/logback/mask/PatternMaskingLayoutTest.java
+++ b/src/test/java/dev/vality/adapter/flow/lib/logback/mask/PatternMaskingLayoutTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
 
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -115,6 +117,11 @@ public class PatternMaskingLayoutTest {
             }
 
             @Override
+            public List<Marker> getMarkerList() {
+                return null;
+            }
+
+            @Override
             public Map<String, String> getMDCPropertyMap() {
                 return null;
             }
@@ -127,6 +134,21 @@ public class PatternMaskingLayoutTest {
             @Override
             public long getTimeStamp() {
                 return date.getTime();
+            }
+
+            @Override
+            public int getNanoseconds() {
+                return 0;
+            }
+
+            @Override
+            public long getSequenceNumber() {
+                return 0;
+            }
+
+            @Override
+            public List<KeyValuePair> getKeyValuePairs() {
+                return null;
             }
 
             @Override


### PR DESCRIPTION
Spring Boot 3.3.1 -> 4.0.6, Jackson 2 -> 3, parent pom 4.0.0, versions from the BOM. logstash-logback-encoder 9.0 for the Jackson 3 line, and MaskedEvent implements the ILoggingEvent methods added in Logback 1.5.

Align woody 3.0.0, damsel 1.698-99c91c9, bender-proto 1.27-753b935, cds-proto 1.71-b3db02c and geck 1.0.2 with adapter-common-lib 4.0.0.

Declare woody-api, libthrift and msgpack-proto explicitly, they no longer arrive transitively. Drop the unused commons-codec. Move CI to java-workflow@v4 on JDK 25, as the parent pom now targets 25.